### PR TITLE
Remove AccessLint from the required checks

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -37,7 +37,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ['markdown-link-check', 'AccessLint']
+        contexts: ['markdown-link-check']
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.


### PR DESCRIPTION
All AccessLint checks appear to be hanging, I think because you can only attach a free AccessLint account to a personal GitHub account, and we're using an organization.

Hopefully this fixes that.